### PR TITLE
Fix #6: Can't fix file, if source file is write protected

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -56,6 +56,8 @@ public class Program
         // Package does not have a SaveAs() method. It can be modified in place only.
         // So, let's work on the destination file immediately.
         File.Copy(inputFileName, outputFileName);
+        // If the source was readonly, then the copy is read-only as well. Make it writable, because we want to fix it.
+        new FileInfo(outputFileName).IsReadOnly = false;
         using var package = Package.Open(outputFileName, FileMode.Open, FileAccess.ReadWrite);
 
         new RelationshipFixer().Fix(package, _fixes);


### PR DESCRIPTION
Removing the read-only flag on the copied file.